### PR TITLE
apply suppress_dimvals for GMT netcdf

### DIFF
--- a/R/connection.R
+++ b/R/connection.R
@@ -51,7 +51,7 @@ setMethod('readStart', signature(x='RasterStack'),
 			x@file@open <- TRUE
 		}
 	} else if (driver == 'netcdf') {
-		attr(x@file, 'con') <- ncdf4::nc_open(x@file@name)
+		attr(x@file, 'con') <- ncdf4::nc_open(x@file@name, suppress_dimvals = TRUE)
 		x@file@open <- TRUE
 #	} else if (driver == 'ascii') { # cannot be opened
 	}	

--- a/R/netCDFread.R
+++ b/R/netCDFread.R
@@ -13,7 +13,7 @@
 	if (is.open) {
 		nc <- x@file@con
 	} else {
-		nc <- ncdf4::nc_open(x@file@name)
+		nc <- ncdf4::nc_open(x@file@name, suppress_dimvals = TRUE)
 		on.exit( ncdf4::nc_close(nc) )		
 	}
 	
@@ -112,7 +112,7 @@
 	if (is.open) {
 		nc <- x@file@con
 	} else {
-		nc <- ncdf4::nc_open(x@file@name)
+		nc <- ncdf4::nc_open(x@file@name, suppress_dimvals = TRUE)
 		on.exit( ncdf4::nc_close(nc) )		
 	}
 	zvar <- x@data@zvar

--- a/R/netCDFreadCells.R
+++ b/R/netCDFreadCells.R
@@ -39,7 +39,7 @@
 	zvar = x@data@zvar
 	time = x@data@band
 	
-	nc <- ncdf4::nc_open(x@file@name)
+	nc <- ncdf4::nc_open(x@file@name, suppress_dimvals = TRUE)
 	on.exit( ncdf4::nc_close(nc) )		
 	getfun <- ncdf4::ncvar_get
 
@@ -124,7 +124,7 @@
 	}
 		
 
-	nc <- ncdf4::nc_open(x@file@name)
+	nc <- ncdf4::nc_open(x@file@name, suppress_dimvals = TRUE)
 	on.exit( ncdf4::nc_close(nc) )		
 	getfun <- ncdf4::ncvar_get
 	

--- a/R/netCDFtoRasterCD.R
+++ b/R/netCDFtoRasterCD.R
@@ -123,7 +123,7 @@
 
 	stopifnot(requireNamespace("ncdf4"))
 
-	nc <- ncdf4::nc_open(filename)
+	nc <- ncdf4::nc_open(filename, suppress_dimvals = TRUE)
 	on.exit( ncdf4::nc_close(nc) )		
 	conv <- ncdf4::ncatt_get(nc, 0, "Conventions")
 		

--- a/R/netCDFtoRasterCD.R
+++ b/R/netCDFtoRasterCD.R
@@ -8,7 +8,7 @@
 .doTime <- function(x, nc, zvar, dim3) {
 	dodays <- TRUE
 	dohours <- FALSE
-	
+
 	un <- nc$var[[zvar]]$dim[[dim3]]$units	
 	if (substr(un, 1, 10) == "days since") { 
 		startDate = as.Date(substr(un, 12, 22))
@@ -166,7 +166,9 @@
 	ncols <- nc$var[[zvar]]$dim[[dims[1]]]$len
 	nrows <- nc$var[[zvar]]$dim[[dims[2]]]$len
 
-	xx <- nc$var[[zvar]]$dim[[dims[1]]]$vals
+	## to allow suppress_dimvals
+	## xx <- nc$var[[zvar]]$dim[[dims[1]]]$vals
+	xx <- ncdf4::ncvar_get(nc, nc$var[[zvar]]$dim[[dims[1]]]$name)
 	rs <- xx[-length(xx)] - xx[-1]
 	if (! isTRUE ( all.equal( min(rs), max(rs), tolerance=0.025, scale= abs(min(rs))) ) ) {
 		if (is.na(stopIfNotEqualSpaced)) {
@@ -181,8 +183,10 @@
 	resx <- (xrange[2] - xrange[1]) / (ncols-1)
 	rm(xx)
 
+	## to allow suppress_dimvals
+  ##	yy <- nc$var[[zvar]]$dim[[dims[2]]]$vals
+	yy <- ncdf4::ncvar_get(nc, nc$var[[zvar]]$dim[[dims[2]]]$name)
 	
-	yy <- nc$var[[zvar]]$dim[[dims[2]]]$vals
 	rs <- yy[-length(yy)] - yy[-1]
 	if (! isTRUE ( all.equal( min(rs), max(rs), tolerance=0.025, scale= abs(min(rs))) ) ) {
 		if (is.na(stopIfNotEqualSpaced)) {
@@ -294,7 +298,9 @@
 	} else {
 		nbands <- nc$var[[zvar]]$dim[[dim3]]$len
 		r@file@nbands <- nbands
-		r@z <- list( nc$var[[zvar]]$dim[[dim3]]$vals )
+		## to allow suppress_dimvals
+  	#	r@z <- list( nc$var[[zvar]]$dim[[dim3]]$vals )
+		r@z <- list(ncdf4::ncvar_get(nc, nc$var[[zvar]]$dim[[dim3]]$name))
 		if ( nc$var[[zvar]]$dim[[dim3]]$name == 'time' ) {
 			try( r <- .doTime(r, nc, zvar, dim3) )
 		} else {

--- a/R/netCDFtoStack.R
+++ b/R/netCDFtoStack.R
@@ -8,7 +8,7 @@
 
 	stopifnot(requireNamespace("ncdf4"))
 
-	nc <- ncdf4::nc_open(filename)
+	nc <- ncdf4::nc_open(filename, suppress_dimvals = TRUE)
 	on.exit( ncdf4::nc_close(nc) )		
 
 	zvar <- .varName(nc, varname)

--- a/R/netCDFtoStack.R
+++ b/R/netCDFtoStack.R
@@ -33,7 +33,9 @@
 	st@title <- names(r)
 
 	if (length(bands) > 1) {
-		st@z <- list( nc$var[[zvar]]$dim[[dim3]]$vals[bands] )
+	  ## to enable suppress_dimvals
+	  ##st@z <- list( nc$var[[zvar]]$dim[[dim3]]$vals[bands] )
+	  st@z <- list(ncdf4::ncvar_get(nc, nc$var[[zvar]]$dim[[dim3]]$name)[bands])
 		names(st@z) <- nc$var[[zvar]]$dim[[dim3]]$units
 		if ( nc$var[[zvar]]$dim[[dim3]]$name == 'time' ) {	
 			try( st <- .doTime(st, nc, zvar, dim3)  )

--- a/R/netCDFwriteCD.R
+++ b/R/netCDFwriteCD.R
@@ -156,7 +156,7 @@
 
 
 .stopWriteCDF <-  function(x) {
-	nc <- ncdf4::nc_open(x@file@name, write=TRUE)
+	nc <- ncdf4::nc_open(x@file@name, write=TRUE, suppress_dimvals = TRUE)
 	on.exit( ncdf4::nc_close(nc) )
 	ncdf4::ncatt_put(nc, x@title, 'min', as.numeric(x@data@min))
 	ncdf4::ncatt_put(nc, x@title, 'max', as.numeric(x@data@max))
@@ -183,7 +183,7 @@
 	nr <- length(v) / x@ncols
 	v <- matrix(v, ncol=nr)
 
-	nc <- ncdf4::nc_open(x@file@name, write=TRUE)
+	nc <- ncdf4::nc_open(x@file@name, write=TRUE, suppress_dimvals = TRUE)
 	on.exit( ncdf4::nc_close(nc) )
 	try ( ncdf4::ncvar_put(nc, x@title, v, start=c(1, start), count=c(x@ncols, nr)) )
 	return(x)
@@ -224,7 +224,7 @@
 	rows <- length(v) / (ncols * nl)
 	v <- array(v, c(rows, ncols, nl))
 
-	nc <- ncdf4::nc_open(x@file@name, write=TRUE)
+	nc <- ncdf4::nc_open(x@file@name, write=TRUE, suppress_dimvals = TRUE)
 	on.exit( ncdf4::nc_close(nc) )
 	try ( ncdf4::ncvar_put(nc, x@title, v, start=c(1, start, lstart), count=c(ncols, rows, lend) ) )
 	

--- a/R/netCDFwriteCD.R
+++ b/R/netCDFwriteCD.R
@@ -156,7 +156,7 @@
 
 
 .stopWriteCDF <-  function(x) {
-	nc <- ncdf4::nc_open(x@file@name, write=TRUE, suppress_dimvals = TRUE)
+	nc <- ncdf4::nc_open(x@file@name, write=TRUE)
 	on.exit( ncdf4::nc_close(nc) )
 	ncdf4::ncatt_put(nc, x@title, 'min', as.numeric(x@data@min))
 	ncdf4::ncatt_put(nc, x@title, 'max', as.numeric(x@data@max))

--- a/R/print.R
+++ b/R/print.R
@@ -11,7 +11,7 @@ setMethod ('print', 'Raster',
 			show(x)
 		} else {
 			if (x@file@driver == 'netcdf') {
-				nc <- ncdf4::nc_open(x@file@name)
+				nc <- ncdf4::nc_open(x@file@name, suppress_dimvals = TRUE)
 				print(nc)
 				ncdf4::nc_close(nc)
 			} else if (any(is.factor(x))) {

--- a/R/update.R
+++ b/R/update.R
@@ -271,7 +271,7 @@ function(object, v, cell, band, ...) {
 
 .updateNCDF <- function(object, v, cell, band) {
 		
-		nc <- ncdf4::nc_open(object@file@name, write=TRUE)
+		nc <- ncdf4::nc_open(object@file@name, write=TRUE, suppress_dimvals = TRUE)
 		on.exit( ncdf4::nc_close(nc) )		
 
 		zvar <- object@data@zvar

--- a/R/update.R
+++ b/R/update.R
@@ -271,7 +271,7 @@ function(object, v, cell, band, ...) {
 
 .updateNCDF <- function(object, v, cell, band) {
 		
-		nc <- ncdf4::nc_open(object@file@name, write=TRUE, suppress_dimvals = TRUE)
+		nc <- ncdf4::nc_open(object@file@name, write=TRUE)
 		on.exit( ncdf4::nc_close(nc) )		
 
 		zvar <- object@data@zvar


### PR DESCRIPTION
When `ncdf4` opens a GMT-variant NetCDF, the object contains an unused index in the "xysize" dimension. 

This can be pretty big, for the [IBCSO bathymetry](https://www.scar.org/science/ibcso/ibcso/) it creates a 712 Mb connection object every time `nc_open` is called.  

(Please note that NetCDF GMT tends to have ".grd" extension", so care must be taken not to conflate this with rasterfile .grd). 

Here's a small example, see that the `ncdf4` connection object is large if `suppress_dimvals` is FALSE: 

```R
r <- disaggregate(raster(volcano), fact = 20)
rgdal::writeGDAL(as(r, "SpatialGridDataFrame"), "file.grd", drivername = "GMT")
system("gdalinfo file.grd")
# Driver: GMT/GMT NetCDF Grid Format
# Files: file.grd
# file.grd.aux.xml
# Size is 1220, 1740
file.info("file.grd")$size
#8491796

nc <- nc_open("file.grd")
pryr::object_size(nc)  ## as large as the data
#8.51 MB
nc0 <- nc_open("file.grd", suppress_dimvals = TRUE)
pryr::object_size(nc0)  ## tiny!
#18 kB
```

This doesn't affect a raster object size as far as I can see, but every time the file is opened this xysize vector is instantiated. 

I believe it's enough to `suppress_dimvals = TRUE` throughout. 
