### PR TITLE
Changes in computation of memory requirements

### DIFF
--- a/R/blockSize.R
+++ b/R/blockSize.R
@@ -8,20 +8,20 @@ blockSize <- function(x, chunksize, n=nlayers(x), minblocks=4, minrows=1) {
 
 	n <- max(n, 1)
 	if (missing(chunksize)) {
-		bs <- .chunksize()  / n
+		bs <- .chunksize()
 	} else {
 		bs <- chunksize
 	}
-	
+
 	blockrows <- try(methods::slot(x@file, 'blockrows'), silent=TRUE)
 	if (class(blockrows) == 'try-error') {
 		blockrows <- 1
 	}
 	blockrows <- max(blockrows, 1)
-	
-		
+
+
 	nr <- nrow(x)
-	size <- min(nr, max(1, floor(bs / ncol(x))))
+	size <- min(nr, max(1, floor(bs / (ncol(x) * n * 8))))
 	# min number of chunks
 	if (size > 1) {
 		minblocks <- min(nr, max(1, minblocks))
@@ -29,14 +29,14 @@ blockSize <- function(x, chunksize, n=nlayers(x), minblocks=4, minrows=1) {
 	}
 	size <- min(max(size, minrows), nr)
 	size <- max(minrows, blockrows * round(size / blockrows))
-	
+
 	nb <- ceiling(nr / size)
 	row <- (0:(nb-1))*size + 1
 	nrows <- rep(size, length(row))
 
 	dif = nb * size - nr
 	nrows[length(nrows)] = nrows[length(nrows)] - dif
-	
+
 	return(list(row=row, nrows=nrows, n=nb))
 }
 

--- a/R/canProcessInMemory.R
+++ b/R/canProcessInMemory.R
@@ -7,8 +7,8 @@
 canProcessInMemory <- function(x, n=4) {
 
 
-# for testing purposes	
-#	rasterOptions(format='GTiff') 
+# for testing purposes
+#	rasterOptions(format='GTiff')
 #	requireNamespace("ncdf4")
 #	requireNamespace("rgdal")
 #	rasterOptions(format='big.matrix')
@@ -16,21 +16,21 @@ canProcessInMemory <- function(x, n=4) {
 #	rasterOptions(overwrite=TRUE)
 #  rasterOptions(todisk=TRUE)
 #  return(FALSE)
-	if (.toDisk()) { 
-		return(FALSE) 
-	} 
-	
-	n <- n + nlayers(x)
+	if (.toDisk()) {
+		return(FALSE)
+	}
+
+	n <- n * nlayers(x)
 	memneed <- ncell(x) * n * 8
-	
+
 	if (.estimateMem()) {
-	
+
 		if ( .Platform$OS.type == "windows" ) {
-		
+
 			mem <- system2("wmic", args = "OS get FreePhysicalMemory /Value", stdout = TRUE)
 			mem3 <- gsub("\r", "", mem[3])
 			mem3 <- gsub("FreePhysicalMemory=", "", mem3)
-			memavail <- as.numeric(mem3)
+			memavail <- as.numeric(mem3) * 1024
 
 			#memavail <- 0.5 * (utils::memory.size(NA) - utils::memory.size(FALSE))
 		} else { #if ( .Platform$OS.type == "unix" ) {
@@ -41,22 +41,22 @@ canProcessInMemory <- function(x, n=4) {
 
 		# can't use all of it
 		memavail <- 0.75 * memavail
-		
+
 		#print(paste("mem available:", memavail))
 		#print(paste("mem needed:", memneed))
 
-	
+
 		if (memneed > memavail) {
 			# options(rasterChunkSize = memavail * 0.5 )
 			return(FALSE)
 		} else {
 			return(TRUE)
 		}
-	
+
 	} else {
-		
+
 		if ( memneed > .maxmemory() ) {
-			return(FALSE) 
+			return(FALSE)
 		} else {
 			return(TRUE)
 		}

--- a/man/rasterOptions.Rd
+++ b/man/rasterOptions.Rd
@@ -11,7 +11,7 @@ Set, inspect, reset, save a number of global options used by the raster package.
 
 Most of these options are used when writing files to disk. They can be ignored by specific functions if the corresponding argument is provided as an argument to these functions.
 
-The default location is returned by \code{rasterTmpDir}. It is the same as that of the R temp directory but you can change it (for the current session) with \code{rasterOptions(tmpdir="path")}. 
+The default location is returned by \code{rasterTmpDir}. It is the same as that of the R temp directory but you can change it (for the current session) with \code{rasterOptions(tmpdir="path")}.
 
 To permanently set any of these options, you can add them to \code{<your R installation>/etc/Rprofile.site>}. For example, to change the default directory used to save temporary files, add a line like this: \code{options(rasterTmpDir='c:/temp/')} to that file. All temporary raster files in that folder that are older than 24 hrs are deleted when the raster package is loaded.
 
@@ -19,12 +19,12 @@ Function \code{tmpDir} returns the location of the temporary files
 }
 
 \usage{
-rasterOptions(format, overwrite, datatype, tmpdir, tmptime, progress, 
-     timer, chunksize, maxmemory, todisk, setfileext, tolerance, 
-     standardnames, depracatedwarnings, addheader, estimatemem, default=FALSE)	
+rasterOptions(format, overwrite, datatype, tmpdir, tmptime, progress,
+     timer, chunksize, maxmemory, todisk, setfileext, tolerance,
+     standardnames, depracatedwarnings, addheader, estimatemem, default=FALSE)
 
 
-tmpDir(create=TRUE)	 
+tmpDir(create=TRUE)
 }
 
 
@@ -36,8 +36,8 @@ tmpDir(create=TRUE)
 \item{tmptime}{number > 1. The number of hours after which a temporary file will be deleted. As files are deleted when loading the raster package, this option is only useful if you  save this option so that it is loaded when starting a new session}
 \item{progress}{character. Valid values are "text",  "window" and "" (the default in most functions, no progress bar)}
 \item{timer}{Logical. If \code{TRUE}, the time it took to complete the function is printed}
-\item{chunksize}{integer. Maximum number of cells to read/write in a single chunk while processing (chunk by chunk) disk based Raster* objects}
-\item{maxmemory}{integer. Maximum number of cells to read into memory. I.e., if a Raster* object has more than this number of cells, \code{\link[raster]{canProcessInMemory}} will return \code{FALSE} }
+\item{chunksize}{integer. Maximum number of bytes to read/write in a single chunk while processing (chunk by chunk) disk based Raster* objects}
+\item{maxmemory}{integer. Maximum bytes to read into memory. I.e., if a Raster* function is expected to require more than this value, \code{\link[raster]{canProcessInMemory}} will return \code{FALSE} }
 \item{todisk}{logical. For debugging only. Default is \code{FALSE} and should normally not be changed. If \code{TRUE}, results are always written to disk, even if no filename is supplied (a temporary filename is used)}
 \item{setfileext}{logical. Default is \code{TRUE}. If \code{TRUE}, the file extension will be changed when writing (if known for the file type). E.g. GTiff files will be saved with the .tif extension }
 \item{tolerance}{numeric. The tolerance used when comparing the origin and resolution of Raster* objects. Expressed as the fraction of a single cell. This should be a number between 0 and 0.5 }
@@ -53,12 +53,12 @@ tmpDir(create=TRUE)
 list of the current options (invisibly). If no arguments are provided the options are printed.
 }
 
-\seealso{ \code{\link[base]{options}}, \code{\link[raster]{rasterTmpFile}} }  
+\seealso{ \code{\link[base]{options}}, \code{\link[raster]{rasterTmpFile}} }
 
 \examples{
 \dontrun{
 rasterOptions()
-rasterOptions(chunksize=2e+07) 
+rasterOptions(chunksize=2e+07)
 }
 }
 


### PR DESCRIPTION
-  In CanProcessInMemory, compute "n" as `n * nlayers` instead than `n + nlayers` (since `n` is expressed as "number of copies")
-  In CanProcessInMemory, on windows, multiply memavail by 1024 to get bytes
- In BlockSize, compute "size" based on expected memory requirement instead than on number of cells. Would allow to express also "chunksize" in terms of memory requirements. Also, homogenize behaviour between when `chunksize` is passed explicitly and when it is retrieved from `rasterOptions()`
- Tentative update in documentation of rasterOptions, to document the fact that now maxmemory (and maybe chunksize) are expressed in bytes, and not in number of cells. 