### PR TITLE
projectRaster(alignOnly=TRUE) should not discard all values

### DIFF
--- a/R/projectRaster.R
+++ b/R/projectRaster.R
@@ -126,9 +126,7 @@ projectExtent <- function(object, crs) {
 }
 
 
-.getAlignedRaster <- function(x,y) {
-	x <- raster(x)
-	y <- raster(y)
+.getAlignedRaster <- function(y,x) {
 	p <- projectRaster(x, crs=projection(y))
 	m <- merge(extent(y), extent(p))
 	rx <- extend(y, m)


### PR DESCRIPTION
When using `alignOnly=TRUE`, it seems that the values of the rasters get discarded in the `raster(x)` and `raster(y)` calls (I'm not sure why that is the case). This in turn makes it so that the aligned raster has no values and the warning message `'from' has no cell values` is printed.

In addition, is it intentional that it is "to" that is aligned to "from" in that case? That seems rather counterintuitive. If I swap `x` and `y` around, the result seems to make more sense, the result is a reprojected raster in the projection system of `to`. But perhaps I'm misunderstanding the purpose of the function.