### PR TITLE
Possible repair of returned indices of names. Possible fix of issue #82

### DIFF
--- a/R/stackApply.R
+++ b/R/stackApply.R
@@ -84,9 +84,9 @@ stackApply <- function(x, indices, fun, filename='', na.rm=TRUE, ...) {
 		}
 
 		if (rowcalc) {
-			v <- lapply(uin, function(i) fun(a[, ind==uin[i], drop=FALSE], na.rm=na.rm))
+			v <- lapply(uin, function(i) fun(a[, ind==i, drop=FALSE], na.rm=na.rm))
 		} else {
-			v <- lapply(uin, function(i, ...) apply(a[, ind==uin[i], drop=FALSE], 1, fun, na.rm=na.rm))
+			v <- lapply(uin, function(i, ...) apply(a[, ind==i, drop=FALSE], 1, fun, na.rm=na.rm))
 		}
 		v <- do.call(cbind, v)
 		out <- writeValues(out, v, tr$row[i])


### PR DESCRIPTION
Consistency between the indices of names returned by canProcessInMemory or not.
The problem is also discussed [here]( https://stat.ethz.ch/pipermail/r-sig-geo/2019-November/027811.html)
