### PR TITLE
Clarify help for rcl inside reclassify()

### DIFF
--- a/man/reclassify.Rd
+++ b/man/reclassify.Rd
@@ -20,7 +20,7 @@ Reclassification is done with matrix \code{rcl}, in the row order of the reclass
 \arguments{
   \item{x}{Raster* object}
   
-  \item{rcl}{matrix for reclassification. This matrix must have 3 columns. The first two columns are "from" "to" of the input values, and the third column "becomes" has the new value for that range. (You can also supply a vector that can be coerced into a n*3 matrix (with byrow=TRUE)). You can also provide a two column matrix ("is", "becomes") which can be useful for integer values. In that case, the \code{right} argument is automatically set to \code{NA}}
+  \item{rcl}{matrix for reclassification. This matrix can have 3 or 2 columns. 3-column matrix (the default): The first two columns are "from" "to" of the input values, and the third column "becomes" has the new value for that range. (You can also supply a vector that can be coerced into a n*3 matrix (with byrow=TRUE)). 2-column matrix: You can also provide a two column matrix ("is", "becomes") which can be useful for integer values. In that case, the \code{right} argument is automatically set to \code{NA}}
 
  \item{filename}{character. Output filename (optional) }
   


### PR DESCRIPTION
The parameter rcl inside reclassify() had a misleading help
description. It stated that "This matrix must have 3 columns" which
was not true as it can also be a two column matrix. This commit is an
attempt to provide a clearer help description of the two types of
matrices accepted.