### PR TITLE
fix warning pointing to compare() function

### DIFF
--- a/R/compare_Logical.R
+++ b/R/compare_Logical.R
@@ -383,7 +383,7 @@ setMethod("Compare", signature(e1='Raster', e2='Raster'),
 	
 		cond <- compareRaster(c(r, e2), extent=TRUE, rowcol=TRUE, crs=TRUE, tolerance=0.05, stopiffalse=FALSE) 
 		if (!cond) {
-			stop("Cannot compare Rasters that have different BasicRaster attributes. See compare()")
+			stop("Cannot compare Rasters that have different BasicRaster attributes. See compareRaster()")
 		}	
 		
 		if (canProcessInMemory(r, 3)) {
@@ -424,7 +424,7 @@ setMethod("Logic", signature(e1='Raster', e2='Raster'),
 	
 		cond <- compareRaster(c(r, e2), extent=TRUE, rowcol=TRUE, crs=TRUE, tolerance=0.05, stopiffalse=FALSE) 
 		if (!cond) {
-			stop("Cannot compare Rasters that have different BasicRaster attributes. See compare()")
+			stop("Cannot compare Rasters that have different BasicRaster attributes. See compareRaster()")
 		}	
 		
 		if (canProcessInMemory(r, 3)) {


### PR DESCRIPTION
Error thrown (in my case from a logical operator) points to a function that has been renamed and is no longer exported by the raster package.

```r
library(raster)

r1 <- raster(nrows=108, ncols=21, xmn=0, xmx=10)

r2 <- raster(nrows=108, ncols=21, xmn=4, xmx=10)

r1 | r2
```
```
Error in r1 | r2 : 
  Cannot compare Rasters that have different BasicRaster attributes. See compare()
```

According to the ChangeLog on:

```
--- 7-November-2012, version 2.0-31
...
renamed function 'compare' to 'compareRaster' (to avoid name hiding by the igraph package)
```


