### PR TITLE
Avoid data copy in cellFromRowColCombine

### DIFF
--- a/R/cellRowCol.R
+++ b/R/cellRowCol.R
@@ -57,7 +57,6 @@ cellFromCol <- function(object, colnr) {
 
 setMethod(cellFromRowColCombine, signature(object="BasicRaster", row="numeric", col="numeric"), 
 	function(object, row, col) {
-		object <- raster(object)
 		row[row < 1 | row > object@nrows] <- NA
 		col[col < 1 | col > object@ncols] <- NA
 		cols <- rep(col, times=length(row))

--- a/R/cellRowCol.R
+++ b/R/cellRowCol.R
@@ -57,6 +57,8 @@ cellFromCol <- function(object, colnr) {
 
 setMethod(cellFromRowColCombine, signature(object="BasicRaster", row="numeric", col="numeric"), 
 	function(object, row, col) {
+		# faster without this according to PR #131
+		# object <- raster(object)
 		row[row < 1 | row > object@nrows] <- NA
 		col[col < 1 | col > object@ncols] <- NA
 		cols <- rep(col, times=length(row))


### PR DESCRIPTION
This copy severely impacts the performance of `getValuesBlock` when
reading from an in-memory raster, making it substantially worse than
reading from an on-disk raster. I can't figure out the purpose of
the call to `raster`, since any `BasicRaster` has `nrows` and `ncols`
slots, as far as I can tell.