### PR TITLE
Fix RasterStack getValuesBlock when length(lyrs) == 1

### DIFF
--- a/R/getValuesBlock.R
+++ b/R/getValuesBlock.R
@@ -35,7 +35,7 @@ setMethod('getValuesBlock', signature(x='RasterStack'),
 				stop("no valid layers selected")
 			}
 			nlyrs <- length(lyrs)
-			x <- x[[lyrs]]
+			x <- x[[lyrs, drop=FALSE]]
 		}
 		
 		startcell <- cellFromRowCol(x, row, col)

--- a/tests/testthat/test-getvaluesblock.R
+++ b/tests/testthat/test-getvaluesblock.R
@@ -1,0 +1,14 @@
+context("test-getValuesBlock")
+
+test_that('we can extract from a single layer of a RasterStack using the lyrs argument', {
+  rast <- raster(matrix(1:16, nrow=4),
+                 xmn=0, xmx=4, ymn=0, ymx=4)
+  
+  stk <- stack(list(a=rast, b=sqrt(rast)))
+  
+  expect_equal(
+    getValuesBlock(stk[[1]], 1, 3, 3, 2, format='m'),
+    getValuesBlock(stk, 1, 3, 3, 2, lyrs=1),
+    check.attributes=FALSE
+  )
+})


### PR DESCRIPTION
Avoid decay into RasterLayer and subsequent failure on attempt to access
"layers" slot.

Includes test case.