### PR TITLE
Fixes datetime parsing for CF compliant NetCDF files

### DIFF
--- a/R/netCDFtoRasterCD.R
+++ b/R/netCDFtoRasterCD.R
@@ -18,10 +18,10 @@
 		dodays <- FALSE
 		startTime <- substr(un, 13, 30)
 		mult <- 3600
-	} else if (substr(un, 1, 12) == "seconds from") { 
+	} else if (substr(un, 1, 13) == "seconds since") { 
 		doseconds <- TRUE
 		dodays <- FALSE
-		startTime = as.Date(substr(un, 14, 30))
+		startTime = as.Date(substr(un, 15, 31))
 		mult <- 1
 	}
 	if (!dodays) {

--- a/R/netCDFtoRasterCD.R
+++ b/R/netCDFtoRasterCD.R
@@ -18,7 +18,7 @@
 		dodays <- FALSE
 		startTime <- substr(un, 13, 30)
 		mult <- 3600
-	} else if (substr(un, 1, 13) == "seconds since") { 
+	} else if ((substr(un, 1, 13) == "seconds since") ||  (substr(un, 1, 12) == "seconds from")) { 
 		doseconds <- TRUE
 		dodays <- FALSE
 		startTime = as.Date(substr(un, 15, 31))

--- a/R/netCDFtoRasterCD.R
+++ b/R/netCDFtoRasterCD.R
@@ -23,6 +23,8 @@
 		dodays <- FALSE
 		startTime = as.Date(substr(un, 15, 31))
 		mult <- 1
+	} else {
+	  return(x)
 	}
 	if (!dodays) {
 		start <- strptime(startTime, "%Y-%m-%d %H:%M:%OS", tz = "UTC")


### PR DESCRIPTION
The [CF convention](https://cfconventions.org/cf-conventions/cf-conventions.html#time-coordinate) uses "seconds *since*" for the time coordinate units. This PR tries to fix two things -

1. Updates the string equality check to "seconds since" so that the condition matches units specified as "seconds since 1970-01-01 00:00:00Z"
2. Defaults to returning the third dimension values directly without datetime parsing if the units don't follow one of the "days since", "hours since", or "seconds since" conventions. Without this, `greg` can be `TRUE` even if the origin units are an unknown format, which throws an error at `as.Date(time, origin=startDate)` because `startDate` is unset.

Hope this helps!