### PR TITLE
Don't treat Postgres DSN as a filename

### DIFF
--- a/R/raster.R
+++ b/R/raster.R
@@ -130,7 +130,9 @@ setMethod('raster', signature(x='matrix'),
 
 setMethod('raster', signature(x='character'), 
 	function(x, band=1, ...) {
-		x <- .fullFilename(x)
+		if (substr(x, 1, 3) != 'PG:') {
+			x <- .fullFilename(x)
+		}
 		r <- .rasterObjectFromFile(x, band=band, objecttype='RasterLayer', ...)
 		return(r)
 	}


### PR DESCRIPTION
Allows a raster to be created from PostGIS using, e.g., `raster('PG:dbname=dan table=myrast')`