### PR TITLE
Improve estimates of available memory on Linux and MacOS

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -34,11 +34,8 @@ double availableRAM(double ram) {
 		if (KERN_SUCCESS == host_page_size(mach_port, &page_size) &&
 			KERN_SUCCESS == host_statistics64(mach_port, HOST_VM_INFO,
 											(host_info64_t)&vm_stats, &count)) {
-			long long free_memory = (int64_t)vm_stats.free_count * (int64_t)page_size;
-
-//			long long used_memory = ((int64_t)vm_stats.active_count +
-//									 (int64_t)vm_stats.inactive_count +
-//									 (int64_t)vm_stats.wire_count) *  (int64_t)page_size;
+			long long free_memory = ((int64_t)vm_stats.free_count +
+                               (int64_t)vm_stats.inactive_count) * (int64_t)page_size;
 			ram = free_memory;
 		//https://stackoverflow.com/questions/63166/how-to-determine-cpu-and-memory-consumption-from-inside-a-process
 		}


### PR DESCRIPTION
This implements suggestions from #174 to improve estimates of available memory. If we're unable to determine the available memory from `/proc/meminfo` on Linux, `availableRAM` defaults to returning the value specified by `rasterOptions(maxmemory = <value>)`.

I benchmarked `raster:::.availableRAM(raster:::.maxmemory())` before and after the changes. Surprisingly, using system commands parsing `/proc/meminfo` on Linux were ~40% faster than using `sysinfo` (median 10.4ms vs 18.5ms). 

The long string given to `popen` is ugly but saved from escaping line breaks. We can change if you feel strongly about the formatting.

I'll leave updating DESCRIPTION to you all.

Thanks! Closes #174 