### PR TITLE
Fix URL for SRTM download

### DIFF
--- a/R/getData.R
+++ b/R/getData.R
@@ -407,7 +407,7 @@ ccodes <- function() {
 	if (rowTile < 10) { rowTile <- paste('0', rowTile, sep='') }
 	if (colTile < 10) { colTile <- paste('0', colTile, sep='') }
 
-	baseurl <- "http://srtm.csi.cgiar.org/wp-content/uploads/files/srtm_5x5/TIFF/"
+	baseurl <- "https://srtm.csi.cgiar.org/wp-content/uploads/files/srtm_5x5/TIFF/"
 	
 	f <- paste0("srtm_", colTile, "_", rowTile, ".zip")
 


### PR DESCRIPTION
Currently, the download for SRTM data with getData() fails, because the http link redirects to https, but without the slash between the TLD and the first directory:
```r
trying URL 'http://srtm.csi.cgiar.org/wp-content/uploads/files/srtm_5x5/TIFF/srtm_38_02.zip'
Error in .SRTM(..., download = download, path = path) : 
  cannot download the file
In addition: Warning message:
In utils::download.file(url = aurl, destfile = fn, method = "auto",  :
  URL 'https://srtm.csi.cgiar.orgwp-content/uploads/files/srtm_5x5/TIFF/srtm_38_02.zip': status was 'Couldn't resolve host name'
Error in .SRTM(..., download = download, path = path) : 
  cannot download the file
```

Using HTTPS directly fixes the problem.