### PR TITLE
Recognize spatial_ref and crs_wkt netCDF attributes

### DIFF
--- a/R/netCDFutil.R
+++ b/R/netCDFutil.R
@@ -19,8 +19,8 @@
 		crs <- vals[vars=="epsg_code"] 
 		crs <- paste0("+init=epsg:", crs)
 		return(crs)
-	} else if (any(vars == "proj4")) {
-		crs=vals[vars=="proj4"] 
+	} else if (any(vars %in% c("proj4", "crs_wkt", "spatial_ref"))) {
+		crs=vals[vars %in% c("proj4", "crs_wkt", "spatial_ref")][1]
 		return(crs)
 	}
 # based on info at 


### PR DESCRIPTION
Version 1.7 of the CF conventions allows for a coordinate reference
system to be stored as a "crs_wkt" attribute of the "crs" variable.
Where conflict exists between the crs_wkt attribute and the other
attributes of the crs variable, the crs_wkt variable is specified to
take precedence. Therefore, this commit checks for the presence of the
crs_wkt attribute and ignores the remainder of the crs attributes if it
is found.

GDAL used a "spatial_ref" attribute for this purpose for many years
before the CF conventions adopted the approach but changed the variable
name. GDAL continues to use "spatial_ref" instead of "crs_wkt" so this
commit recognizes both variants.