### PR TITLE
add CMIP6 to `getData()`

### DIFF
--- a/R/getData.R
+++ b/R/getData.R
@@ -18,7 +18,7 @@ getData <- function(name='GADM', download=TRUE, path='', ...) {
 	} else if (name=='CMIP5') {
 		.cmip5(..., download=download, path=path)
 	} else if (name=='CMIP6') {
-	  .cmip6(..., ddownload=download, path=path)
+	  .cmip6(..., download=download, path=path)
 	} else if (name=='ISO3') {
 		ccodes()[,c(2,1)]
 	} else if (name=='countries') {
@@ -199,7 +199,7 @@ ccodes <- function() {
 }
 
 
-.cmip5 <- function(var, model, rcp, year, res, lon, lat, path, download=TRUE) {
+.cmip5 <- function(var, model, rcp, year, res, path, download=TRUE) {
 	if (!res %in% c(0.5, 2.5, 5, 10)) {
 		stop('resolution should be one of: 2.5, 5, 10')
 	}
@@ -267,7 +267,7 @@ ccodes <- function() {
 
 #.cmip5(var='prec', model='BC', rcp=26, year=50, res=10, path=getwd())
 
-.cmip6 <- function(var, model, ssp, year, res, lon, lat, path, download=TRUE) {
+.cmip6 <- function(var, model, ssp, year, res, path, download=TRUE) {
   if (!res %in% c(2.5, 5, 10)) {
     stop('resolution should be one of: 2.5, 5, 10')
   }

--- a/R/getData.R
+++ b/R/getData.R
@@ -302,9 +302,19 @@ ccodes <- function() {
   year <- year + 2000
   yrange <- paste(year-19, year, sep = "-")
   
-  #TODO check for combinations that aren't available
+  #Check for combinations that aren't available
+  if(model == "GFDL-ESM4") {
+    if(ssp == 245) {
+      warning('this combination of ssp and model is not available')
+      return(invisible(NULL))
+    }
+    if(ssp == 585 & var %in% c("tmin", "tmax", "bio", "bioc")) {
+      warning('this combination of ssp and model is not available')
+      return(invisible(NULL))
+    }
+  }
   
-  #creat download dir
+  #create download dir
   path <- paste0(path, '/cmip6/', res, '/')
   dir.create(path, recursive=TRUE, showWarnings=FALSE)
   

--- a/man/getData.Rd
+++ b/man/getData.Rd
@@ -14,7 +14,7 @@ ccodes()
 }
 
 \arguments{
-  \item{name}{Data set name, currently supported are 'GADM', 'countries', 'SRTM', 'alt', 'worldclim', and 'CMIP5'. See Details for more info}
+  \item{name}{Data set name, currently supported are 'GADM', 'countries', 'SRTM', 'alt', 'worldclim', 'CMIP5' and 'CMIP6'. See Details for more info}
   \item{download}{Logical. If \code{TRUE} data will be downloaded if not locally available}
   \item{path}{Character. Path name indicating where to store the data. Default is the current working directory }
   \item{...}{ Additional required (!) parameters. These are data set specific. See Details}   

--- a/man/getData.Rd
+++ b/man/getData.Rd
@@ -14,7 +14,7 @@ ccodes()
 }
 
 \arguments{
-  \item{name}{Data set name, currently supported are 'GADM', 'countries', 'SRTM', 'alt', and 'worldclim'. See Details for more info}
+  \item{name}{Data set name, currently supported are 'GADM', 'countries', 'SRTM', 'alt', 'worldclim', and 'CMIP5'. See Details for more info}
   \item{download}{Logical. If \code{TRUE} data will be downloaded if not locally available}
   \item{path}{Character. Path name indicating where to store the data. Default is the current working directory }
   \item{...}{ Additional required (!) parameters. These are data set specific. See Details}   
@@ -45,7 +45,7 @@ If \code{name='worldclim'} you must also provide arguments \code{var}, and a res
 \code{getData('worldclim', var='bio', res=10)}
 
 
-To get (projected) future climate data (CMIP5), you must provide arguments \code{var} and \code{res} as above. Only resolutions 2.5, 5, and 10 are currently available. In addition, you need to provide \code{model}, \code{rcp} and \code{year}. For example,
+To get (projected) future climate data (CMIP5), you must provide arguments \code{var} and \code{res} as above. Only resolutions 0.5, 2.5, 5, and 10 are currently available. In addition, you need to provide \code{model}, \code{rcp}, and \code{year}. For example,
 
 \code{getData('CMIP5', var='tmin', res=10, rcp=85, model='AC', year=70)}
 

--- a/man/getData.Rd
+++ b/man/getData.Rd
@@ -45,17 +45,27 @@ If \code{name='worldclim'} you must also provide arguments \code{var}, and a res
 \code{getData('worldclim', var='bio', res=10)}
 
 
-To get (projected) future climate data (CMIP5), you must provide arguments \code{var} and \code{res} as above. Only resolutions 0.5, 2.5, 5, and 10 are currently available. In addition, you need to provide \code{model}, \code{rcp}, and \code{year}. For example,
+To get (projected) future climate data (CMIP5 or CMIP6), you must provide arguments \code{var} and \code{res} as above. Only resolutions 2.5, 5, and 10 are currently available for CMIP6. For CMIP5, resolution 0.5 (30s) is also available. In addition, you need to provide \code{model}, \code{rcp} (CMIP5) or \code{ssp} (CMIP6), and \code{year}. For example,
 
 \code{getData('CMIP5', var='tmin', res=10, rcp=85, model='AC', year=70)}
 
-function (var, model, rcp, year, res, lon, lat, path, download = TRUE) 
+function (var, model, rcp, year, res, path, download = TRUE) 
 
 'model' should be one of "AC", "BC", "CC", "CE", "CN", "GF", "GD", "GS", "HD", "HG", "HE", "IN", "IP", "MI", "MR", "MC", "MP", "MG", or  "NO".
 
 'rcp' should be one of 26, 45, 60, or 85.
 
 'year' should be 50 or 70
+
+An example for CMIP6:
+
+\code{getData('CMIP6', var = 'prec', res = 5, ssp = 245, model = "GFDL-ESM4", year = 80)}
+
+'model' should be one of "BCC-CSM2-MR", "CNRM-CM6-1", "CNRM-ESM2-1", "CanESM5", "GFDL-ESM4", "IPSL-CM6A-LR", "MIROC-ES2L", "MIROC6", or "MRI-ESM2-0".
+
+'ssp' should be 126, 245, 370, or 585
+
+'year' should be 40, 60, 80, or 100
 
 Not all combinations are available. See www.worldclim.org for details.
 }


### PR DESCRIPTION
I decided to just work on code for #211 this afternoon. 
This PR adds a `.cmip6()` function to `getData()` modeled after the `.cmip5()` function to download downscaled CMIP6 data from worldclim.org.  It also fixes some mistakes in the documentation for `getData()`.

I didn't edit NEWS because opening it changed some special characters to "?"'s.  I didn't add any formal tests, but I did test a few examples and they worked.