### PR TITLE
remove method="auto" from download.file call

### DIFF
--- a/R/getData.R
+++ b/R/getData.R
@@ -35,7 +35,7 @@ getData <- function(name='GADM', download=TRUE, path='', ...) {
 
 .download <- function(aurl, filename) {
 	fn <- paste(tempfile(), '.download', sep='')
-	res <- utils::download.file(url=aurl, destfile=fn, method="auto", quiet = FALSE, mode = "wb", cacheOK = TRUE)
+	res <- utils::download.file(url=aurl, destfile=fn, quiet = FALSE, mode = "wb", cacheOK = TRUE)
 	if (res == 0) {
 		w <- getOption('warn')
 		on.exit(options('warn' = w))


### PR DESCRIPTION
Having hard-coded `method="auto"` prevents users from changing the method with `options("download.file.method" = ...)`. 
However, if this option is not set, the `method = "auto"` is chosen anyway, so there wouldn't be any unexpected behaviour changes for users.
This should help with errors like - https://github.com/rspatial/raster/issues/169#issuecomment-938102190 - since users would be able to call:
```r
op <- options("download.file.method" = "wget", "download.file.extra" = "--no-check-certificate")
getData(...)
options(op)
```