### PR TITLE
Minor improvements of documentation texts

### DIFF
--- a/man/aggregate.Rd
+++ b/man/aggregate.Rd
@@ -31,7 +31,7 @@ Aggregate a SpatialPolygon* object, optionally by combining polygons that have t
   \item{x}{Raster* object or SpatialPolygons* object}
   \item{fact}{postive integer. Aggregation factor expressed as number of cells in each direction (horizontally and vertically). Or two integers (horizontal and vertical aggregation factor) or three integers (when also aggregating over layers). See Details}  
   \item{fun}{function used to aggregate values }  
-  \item{expand}{logical. If \code{TRUE} the output Raster* object will be larger then the input Raster* object if a division of the number of columns or rows with \code{factor} is not an integer}
+  \item{expand}{logical. If \code{TRUE} the output Raster* object will be larger than the input Raster* object if a division of the number of columns or rows with \code{factor} is not an integer}
   \item{na.rm}{logical. If \code{TRUE}, NA cells are removed from calculations }
   \item{filename}{character. Output filename (optional)}
   \item{...}{if \code{x} is a Raster* object, additional arguments as for \code{\link{writeRaster}}}

--- a/man/crop.Rd
+++ b/man/crop.Rd
@@ -31,10 +31,10 @@ If \code{x} is a Raster* object, the Extent is aligned to \code{x}. Areas includ
 \note{values within the extent of a Raster* object can be set to NA with \link[raster]{mask}}
 
 \details{
-Objects from which an Extent can be extracted/created include RasterLayer, RasterStack, RasterBrick and objects of the Spatial* classes from the sp package. You can check this with the \code{\link[raster]{extent}} function. New Extent objects can be also be created with function \code{\link{extent}} and \code{\link{drawExtent}} by clicking twice on a plot.
+Objects from which an Extent can be extracted/created include RasterLayer, RasterStack, RasterBrick and objects of the Spatial* classes from the sp package. You can check this with the \code{\link[raster]{extent}} function. New Extent objects can also be created with function \code{\link{extent}} and \code{\link{drawExtent}} by clicking twice on a plot.
 
 To crop by row and column numbers you can create an extent like this (for Raster \code{x}, row 5 to 10, column 7 to 12)
-\code{crop(x, extent(x, 5, 10, 7, 15))}
+\code{crop(x, extent(x, 5, 10, 7, 12))}
 }
 
 \value{

--- a/man/extend.Rd
+++ b/man/extend.Rd
@@ -10,7 +10,7 @@
 \description{
 Extend returns an Raster* object with a larger spatial extent. The output Raster object has the outer minimum and maximum coordinates of the input Raster and Extent arguments. Thus, all of the cells of the original raster are included. See \code{\link[raster]{crop}} if you (also) want to remove rows or columns. 
 
-There is also an extend method for Extent objects to enlarge (or reduce) an Extent. You can also use algebraic notation to do that (see examples)
+There is also an extend method for Extent objects to enlarge (or reduce) an Extent. You can also use algebraic notation to do that (see examples).
 
 This function has replaced function "expand" (to avoid a name conflict with the Matrix package).
 }


### PR DESCRIPTION
I was just reading through the documentation of `resample` and its "see also" functions for my master thesis -- while doing so I stumbled across a few minor typos that don't really hurt (an exception may be the example in `crop.Rd` -- I _really_ hope that was just a typo, otherwise the usage would be highly un-intuitive ;)) but look nicer fixed anyway so here I go :tipping_hand_man: 