### PR TITLE
change comment wkt in iniFile.R

### DIFF
--- a/R/inifile.R
+++ b/R/inifile.R
@@ -30,7 +30,7 @@
 }
 
 	
-readIniFile <- function(filename, token='=', commenttoken=';', wkttoken = "#", aslist=FALSE, case) {
+readIniFile <- function(filename, token='=', commenttoken=';', aslist=FALSE, case) {
 
     stopifnot(file.exists(filename))
 	
@@ -41,7 +41,7 @@ readIniFile <- function(filename, token='=', commenttoken=';', wkttoken = "#", a
                 res <- .strSplitOnFirstToken(s, token=commenttoken)
             } else {
 # if WKT2 do not split, no comment permitted
-                res <- .strSplitOnFirstToken(s, token=wkttoken)
+                res <- c(trim(s), NA)
             } 
             res 
         } ) 

--- a/R/inifile.R
+++ b/R/inifile.R
@@ -30,13 +30,21 @@
 }
 
 	
-readIniFile <- function(filename, token='=', commenttoken=';', aslist=FALSE, case) {
+readIniFile <- function(filename, token='=', commenttoken=';', wkttoken = "#", aslist=FALSE, case) {
 
     stopifnot(file.exists(filename))
 	
 	Lines <- trim(readLines(filename,  warn = FALSE))
 	
-	ini <- lapply(Lines, function(s){ .strSplitOnFirstToken(s, token=commenttoken) } ) 
+	ini <- lapply(Lines, function(s){ 
+            if (strsplit(s, "=")[[1]][1] != "wkt") {
+                res <- .strSplitOnFirstToken(s, token=commenttoken)
+            } else {
+# if WKT2 do not split, no comment permitted
+                res <- .strSplitOnFirstToken(s, token=wkttoken)
+            } 
+            res 
+        } ) 
 	Lines <- matrix(unlist(ini), ncol=2, byrow=TRUE)[,1]
 	ini <- lapply(Lines, function(s){ .strSplitOnFirstToken(s, token=token) }) 
 	

--- a/man/iniFile.Rd
+++ b/man/iniFile.Rd
@@ -9,14 +9,13 @@ This function reads  \code{'.ini'}  files. These are text file databases that ar
 }
 
 \usage{
-readIniFile(filename, token='=', commenttoken=';', wkttoken = "#", aslist=FALSE, case)
+readIniFile(filename, token='=', commenttoken=';', aslist=FALSE, case)
 }
 
 \arguments{
   \item{filename}{Character. Filename of the .ini file}
   \item{token}{Character. The character that separates the "name" (variable name) from the "value"}
   \item{commenttoken}{Character. This token and everything that follows on the same line is considered a 'comment' that is not for machine consumption and is ignored in processing} 
-  \item{wkttoken}{Character. Used when key is \dQuote{wkt}}
   \item{aslist}{Logical. Should the values be returned as a list}
   \item{case}{Optional. Function that operates on the text, such as \code{\link{toupper}} or  \code{\link{tolower}} }
 }

--- a/man/iniFile.Rd
+++ b/man/iniFile.Rd
@@ -9,13 +9,14 @@ This function reads  \code{'.ini'}  files. These are text file databases that ar
 }
 
 \usage{
-readIniFile(filename, token='=', commenttoken=';', aslist=FALSE, case)
+readIniFile(filename, token='=', commenttoken=';', wkttoken = "#", aslist=FALSE, case)
 }
 
 \arguments{
   \item{filename}{Character. Filename of the .ini file}
   \item{token}{Character. The character that separates the "name" (variable name) from the "value"}
   \item{commenttoken}{Character. This token and everything that follows on the same line is considered a 'comment' that is not for machine consumption and is ignored in processing} 
+  \item{wkttoken}{Character. Used when key is \dQuote{wkt}}
   \item{aslist}{Logical. Should the values be returned as a list}
   \item{case}{Optional. Function that operates on the text, such as \code{\link{toupper}} or  \code{\link{tolower}} }
 }


### PR DESCRIPTION
It turned out that WKT2 CRS can contain `";"` (the comment separator), so this PR does not split the value for the `wkt:` key at all.