### PR TITLE
put [georeference] last in wriiting grd header

### DIFF
--- a/R/hdrRaster.R
+++ b/R/hdrRaster.R
@@ -11,19 +11,6 @@
 	cat("creator=R package 'raster'", "\n", file = thefile, sep='')
 	cat("created=", format(Sys.time(), "%Y-%m-%d %H:%M:%S"), "\n", file = thefile, sep='')
 
-	cat("[georeference]", "\n", file = thefile, sep='')
-	cat("nrows=",  nrow(x), "\n", file = thefile, sep='')
-	cat("ncols=",  ncol(x), "\n", file = thefile, sep='')
-	cat("xmin=", as.character(xmin(x)), "\n", file = thefile, sep='')
-	cat("ymin=", as.character(ymin(x)), "\n", file = thefile, sep='')
-	cat("xmax=", as.character(xmax(x)), "\n", file = thefile, sep='')
-	cat("ymax=", as.character(ymax(x)), "\n", file = thefile, sep='')
-	cat("projection=", proj4string(x), "\n", file = thefile, sep='')
-# update to add WKT2
-        if (!is.null(comment(crs(x))))
-            cat("wkt=", gsub("\\n", "", wkt(x)), "\n",
-                file = thefile, sep='')
-
 	cat("[data]", "\n", file = thefile, sep='')
 	cat("datatype=",  x@file@datanotation, "\n", file = thefile, sep='')
 	cat("byteorder=", x@file@byteorder, "\n", file = thefile, sep='')
@@ -100,6 +87,20 @@
 		cat("[metadata]", "\n", file = thefile, sep='')
 		cat(name_type_value, file = thefile, sep='')		
 	}
+
+	cat("[georeference]", "\n", file = thefile, sep='')
+	cat("nrows=",  nrow(x), "\n", file = thefile, sep='')
+	cat("ncols=",  ncol(x), "\n", file = thefile, sep='')
+	cat("xmin=", as.character(xmin(x)), "\n", file = thefile, sep='')
+	cat("ymin=", as.character(ymin(x)), "\n", file = thefile, sep='')
+	cat("xmax=", as.character(xmax(x)), "\n", file = thefile, sep='')
+	cat("ymax=", as.character(ymax(x)), "\n", file = thefile, sep='')
+	cat("projection=", proj4string(x), "\n", file = thefile, sep='')
+# update to add WKT2
+        if (!is.null(comment(crs(x))))
+            cat("wkt=", gsub("\\n", "", wkt(x)), "\n",
+                file = thefile, sep='')
+
 	close(thefile)
 	return(TRUE)
 }


### PR DESCRIPTION
In the RRASTER driver, @rouault moved the `[georeference]` ini block last to try to reduce problems with not reading enough characters. This fixes problems in reading files written by **raster** in most cases, but the very large RAT in https://github.com/Nowosad/spDataLarge/tree/master/inst/raster/nlcd.grd (and nlcd2011.grd) after reading and writing with the new RRASTER driver and with **raster** cause problems for the RRASTER driver on GDAL < 3.5.0. That problem is unresolved as yet.