### PR TITLE
Avoid re-opening already opened CDF file.

### DIFF
--- a/R/netCDFwriteCD.R
+++ b/R/netCDFwriteCD.R
@@ -160,12 +160,18 @@
 }
 
 
-.stopWriteCDF <-  function(x) {
+.writeRangeCDF <- function(x) {
+
 	nc <- ncdf4::nc_open(x@file@name, write=TRUE)
 	on.exit( ncdf4::nc_close(nc) )
 	ncdf4::ncatt_put(nc, x@title, 'min', as.numeric(x@data@min))
 	ncdf4::ncatt_put(nc, x@title, 'max', as.numeric(x@data@max))
+}
 
+
+.stopWriteCDF <-  function(x) {
+
+        .writeRangeCDF(x)
 	if (inherits(x, 'RasterBrick')) {
 		r <- brick(x@file@name)
 	} else {


### PR DESCRIPTION
The call to brick() in .stopWriteCDF() may result in an attempt to open the CDF file already opened in .stopWriteCDF() before the call to brick(). This results in an error with hdf5 1.12.1 on Windows due to file locking, which on Windows is no longer a no-op from hdf5 1.12.1. This patch avoids this situation by closing the file, first.

The problem can be reproduced using magclass package. This example fails without this change:

```
  library(magclass)
  md <- magclass:::magclassdata$half_deg
  m05 <- new.magpie(paste0(md$region, ".", seq_len(dim(md)[1])),
                    years = c(2000, 2001), fill = c(md$lon, md$lat))
  m10 <- mbind(m05, m05)
  getNames(m10) <- c("bla", "blub")
  write.magpie(m10, "test.nc")
```

The example is extracted from magclass package tests, which also fail on Windows with Rtools 5863 (hdf5 1.12.1). 

One can also reproduce directly using raster via

``` 
 load("rx.xdr")
 raster::writeRaster(rx, filename = "./test.nc",
        format = "CDF", overwrite = TRUE, compression = 9, zname = "Time",
        zunit = "years", varname = "bla", varunit = "not specified")
```
using the attached file ([rx.zip](https://github.com/rspatial/raster/files/13022720/rx.zip), after unzipping).

For testing, one can also disable hdf5 file locking by setting environment variable `HDF5_USE_FILE_LOCKING=FALSE`. That makes the examples succeed even without the patch.